### PR TITLE
Add slack ruby client

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+SLACK_BOT_TOKEN = your_app_token

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "minitest", "~> 5.0"
+gem "pry"
+gem 'dotenv', "~> 2.7.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.3)
+    dotenv (2.7.6)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     gli (2.19.2)
     hashie (4.1.0)
+    method_source (1.0.0)
     minitest (5.14.2)
     multipart-post (2.1.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rake (12.3.3)
     slack-ruby-client (0.15.1)
       faraday (>= 1.0)
@@ -30,7 +36,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv (~> 2.7.6)
   minitest (~> 5.0)
+  pry
   rake (~> 12.0)
   remote-coffee-slack!
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,38 @@
+PATH
+  remote: .
+  specs:
+    remote-coffee-slack (0.1.0)
+      slack-ruby-client (~> 0.15.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    gli (2.19.2)
+    hashie (4.1.0)
+    minitest (5.14.2)
+    multipart-post (2.1.1)
+    rake (12.3.3)
+    slack-ruby-client (0.15.1)
+      faraday (>= 1.0)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
+    websocket-driver (0.7.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest (~> 5.0)
+  rake (~> 12.0)
+  remote-coffee-slack!
+
+BUNDLED WITH
+   2.1.4

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,12 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
+require 'dotenv/load'
 require "remote_coffee_slack"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
+RemoteCoffeeSlack.configure do |config|
+  config.slack_bot_token = ENV['SLACK_BOT_TOKEN']
+end
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start(__FILE__)
+ require "pry"
+ Pry.start

--- a/lib/remote_coffee_slack.rb
+++ b/lib/remote_coffee_slack.rb
@@ -1,6 +1,23 @@
 require "remote_coffee_slack/version"
 
+require "remote_coffee_slack/slack_client"
+
 module RemoteCoffeeSlack
-  class Error < StandardError; end
-  # Your code goes here...
+  class << self
+    attr_accessor :config
+    attr_accessor :slack_client
+  end
+
+  def self.configure
+    self.config ||= Configuration.new
+    yield config
+  end
+
+  def self.slack_client
+    @slack_client ||= SlackClient.new.client
+  end
+
+  class Configuration
+    attr_accessor :slack_bot_token
+  end
 end

--- a/lib/remote_coffee_slack/slack_client.rb
+++ b/lib/remote_coffee_slack/slack_client.rb
@@ -1,0 +1,16 @@
+require 'slack-ruby-client'
+
+module RemoteCoffeeSlack
+  class SlackClient
+    attr_reader :client
+
+    def initialize
+      ::Slack.configure do |config|
+        config.token = RemoteCoffeeSlack.config.slack_bot_token
+        raise 'Missing API token' unless config.token
+      end
+
+      @client = Slack::Web::Client.new
+    end
+  end
+end

--- a/remote_coffee_slack.gemspec
+++ b/remote_coffee_slack.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_dependency 'slack-ruby-client', '~> 0.15.1'
 end

--- a/remote_coffee_slack.gemspec
+++ b/remote_coffee_slack.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/Calzada-Code/remote-cofee-slack"
+  spec.metadata["changelog_uri"] = "https://github.com/Calzada-Code/remote-cofee-slack"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
    Add slack_client wrapper

    This adds a wrapper for the slack API client, the idea is to user an
    unique instance of the API to perform the slack interaction.
