### PR TITLE
Add proof of concept

### DIFF
--- a/lib/remote_coffee_slack.rb
+++ b/lib/remote_coffee_slack.rb
@@ -1,6 +1,8 @@
 require "remote_coffee_slack/version"
 
 require "remote_coffee_slack/slack_client"
+require "remote_coffee_slack/members"
+require "remote_coffee_slack/session_notifier"
 
 module RemoteCoffeeSlack
   class << self
@@ -15,6 +17,14 @@ module RemoteCoffeeSlack
 
   def self.slack_client
     @slack_client ||= SlackClient.new.client
+  end
+
+  def self.select_coffee_mates
+    @select_coffee_mates ||= Members.select_coffee_mates(slack_client)
+  end
+
+  def self.notify_next_session
+    SessionNotifier.perform(slack_client, select_coffee_mates)
   end
 
   class Configuration

--- a/lib/remote_coffee_slack/members.rb
+++ b/lib/remote_coffee_slack/members.rb
@@ -1,0 +1,38 @@
+module RemoteCoffeeSlack
+  class Members
+    MATES_PER_GROUP = 2
+
+    def initialize(client)
+      @client = client
+      @members = retrieve_all_members
+    end
+
+    def self.select_coffee_mates(client)
+      new(client).select_coffee_mates
+    end
+
+    def select_coffee_mates
+      members_handlers.shuffle.each_slice(MATES_PER_GROUP).to_a
+    end
+
+    private
+
+    attr_reader :client, :members
+
+    def retrieve_all_members
+      all_members = []
+
+      client.users_list(presence: true, limit: 10, sleep_interval: 5, max_retries: 20) do |response|
+        all_members.concat(response.members)
+      end
+
+      all_members
+    end
+
+    def members_handlers
+    members.map do |member|
+      "@#{member.id}|#{member.name}"
+    end
+    end
+  end
+end

--- a/lib/remote_coffee_slack/session_notifier.rb
+++ b/lib/remote_coffee_slack/session_notifier.rb
@@ -1,0 +1,33 @@
+module RemoteCoffeeSlack
+  class SessionNotifier
+    def initialize(client, coffee_mates)
+      @client = client
+      @coffee_mates = coffee_mates
+    end
+
+    def perform
+      client.chat_postMessage(channel: '#general', text: next_session_message, as_user: true)
+    end
+
+    def self.perform(client, coffee_mates)
+      new(client, coffee_mates).perform
+    end
+
+    private
+
+    attr_reader :client, :coffee_mates
+
+    def next_session_message
+      <<-TEXT
+      The mates for the next coffee session are:
+      #{coffee_mates_formated}
+      TEXT
+    end
+
+    def coffee_mates_formated
+      coffee_mates.map do |mates|
+        "<#{mates.first}> and <#{mates.last}>\n"
+      end.join
+    end
+  end
+end


### PR DESCRIPTION
This adds a proof of concept getting all the users from the workspace
and pairing.

![image](https://user-images.githubusercontent.com/2718753/95004361-c48e2e00-05af-11eb-9254-61c122936534.png)


Things to improve in next iterations
- This proof of concept doesn't exclude bots
- Take all the users in the workspace
- Post the match coffee mates to general channel
- The notify session message is hardcoded in english
- I didn't add tests :(

The permissions required for the app are:

chat:write
users:read