### PR TITLE
Get members only from the configured slack channel

### DIFF
--- a/lib/remote_coffee_slack/members.rb
+++ b/lib/remote_coffee_slack/members.rb
@@ -4,7 +4,7 @@ module RemoteCoffeeSlack
 
     def initialize(client)
       @client = client
-      @members = retrieve_all_members
+      @members = retrieve_channel_members
     end
 
     def self.select_coffee_mates(client)
@@ -19,19 +19,31 @@ module RemoteCoffeeSlack
 
     attr_reader :client, :members
 
-    def retrieve_all_members
-      all_members = []
+    def retrieve_channel_members
+      channel_members = []
+      params = {
+        channel: RemoteCoffeeSlack.config.slack_channel,
+        limit: 10,
+        sleep_interval: 5,
+        max_retries: 20
+      }
 
-      client.users_list(presence: true, limit: 10, sleep_interval: 5, max_retries: 20) do |response|
-        all_members.concat(response.members)
+      client.conversations_members(params) do |response|
+        channel_members.concat(response.members)
       end
 
-      all_members
+      channel_members
     end
 
     def members_handlers
-    members.map do |member|
-      "@#{member.id}|#{member.name}"
+      human_members.map do |member|
+        "@#{member}"
+      end
+    end
+
+    def human_members
+    members.reject do |member|
+      client.users_info(user: member).user.is_bot
     end
     end
   end


### PR DESCRIPTION
The application only should match the existing users in a specific channel, bots should be ignored from this pairing.