### PR TITLE
Set default slack channel value to #general

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Initalize the gem adding the following block:
 ```ruby
 RemoteCoffeeSlack.configure do |config|
   config.slack_bot_token = your-Bot-User-OAuth-Access-Token
-  config.slack_channel = the-slack-channel-what-you-will-take-as-water-cooler
+  config.slack_channel = the-slack-channel-what-you-will-take-as-water-cooler # optional (default value is #general)
   config.members_per_group = members-per-group # optional (default value is 2)
 end
 ```

--- a/lib/remote_coffee_slack.rb
+++ b/lib/remote_coffee_slack.rb
@@ -28,6 +28,13 @@ module RemoteCoffeeSlack
   end
 
   class Configuration
-    attr_accessor :slack_bot_token, :slack_channel, :members_per_group
+    DEFAULT_SLACK_CHANNEL = '#general'.freeze
+
+    attr_accessor :slack_bot_token, :members_per_group
+    attr_writer :slack_channel
+
+    def slack_channel
+      @slack_channel || DEFAULT_SLACK_CHANNEL
+    end
   end
 end

--- a/lib/remote_coffee_slack.rb
+++ b/lib/remote_coffee_slack.rb
@@ -30,8 +30,7 @@ module RemoteCoffeeSlack
   class Configuration
     DEFAULT_SLACK_CHANNEL = '#general'.freeze
 
-    attr_accessor :slack_bot_token, :members_per_group
-    attr_writer :slack_channel
+    attr_accessor :slack_bot_token, :slack_channel, :members_per_group
 
     def slack_channel
       @slack_channel || DEFAULT_SLACK_CHANNEL

--- a/test/remote_coffee_slack/members_test.rb
+++ b/test/remote_coffee_slack/members_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class RemoteCoffeeSlack::MembersTest < Minitest::Test
   def setup
-    RemoteCoffeeSlack.config.members_per_group = 2
     @client = RemoteCoffeeSlack::SlackClient.new.client
   end
 
@@ -18,6 +17,7 @@ class RemoteCoffeeSlack::MembersTest < Minitest::Test
       RemoteCoffeeSlack.config.members_per_group = 4
       coffee_mates = RemoteCoffeeSlack::Members.select_coffee_mates(@client)
       assert_equal 1, coffee_mates.count
+      RemoteCoffeeSlack.config.members_per_group = 2
     end
   end
 end

--- a/test/remote_coffee_slack/members_test.rb
+++ b/test/remote_coffee_slack/members_test.rb
@@ -17,7 +17,7 @@ class RemoteCoffeeSlack::MembersTest < Minitest::Test
       RemoteCoffeeSlack.config.members_per_group = 4
       coffee_mates = RemoteCoffeeSlack::Members.select_coffee_mates(@client)
       assert_equal 1, coffee_mates.count
-      RemoteCoffeeSlack.config.members_per_group = 2
+      RemoteCoffeeSlack.config.members_per_group = nil
     end
   end
 end

--- a/test/remote_coffee_slack/members_test.rb
+++ b/test/remote_coffee_slack/members_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
-class RemoteCoffeeSlack::MembersTest  < Minitest::Test
+class RemoteCoffeeSlack::MembersTest < Minitest::Test
   def setup
+    RemoteCoffeeSlack.config.members_per_group = 2
     @client = RemoteCoffeeSlack::SlackClient.new.client
   end
 

--- a/test/remote_coffee_slack_test.rb
+++ b/test/remote_coffee_slack_test.rb
@@ -3,12 +3,12 @@ require "test_helper"
 class RemoteCoffeeSlackTest < Minitest::Test
   def test_default_configuration
     config = RemoteCoffeeSlack::Configuration.new
-    assert_equal config.slack_channel, '#general'
+    assert_equal '#general', config.slack_channel
   end
 
   def test_configuration
     config = RemoteCoffeeSlack::Configuration.new
     config.slack_channel = '#new_channel'
-    assert_equal config.slack_channel, '#new_channel'
+    assert_equal '#new_channel', config.slack_channel
   end
 end

--- a/test/remote_coffee_slack_test.rb
+++ b/test/remote_coffee_slack_test.rb
@@ -5,4 +5,10 @@ class RemoteCoffeeSlackTest < Minitest::Test
     config = RemoteCoffeeSlack::Configuration.new
     assert_equal config.slack_channel, '#general'
   end
+
+  def test_configuration
+    config = RemoteCoffeeSlack::Configuration.new
+    config.slack_channel = '#new_channel'
+    assert_equal config.slack_channel, '#new_channel'
+  end
 end

--- a/test/remote_coffee_slack_test.rb
+++ b/test/remote_coffee_slack_test.rb
@@ -1,4 +1,8 @@
 require "test_helper"
 
 class RemoteCoffeeSlackTest < Minitest::Test
+  def test_default_configuration
+    config = RemoteCoffeeSlack::Configuration.new
+    assert_equal config.slack_channel, '#general'
+  end
 end


### PR DESCRIPTION
This PR:
- adds default slack channel value to #general https://github.com/Calzada-Code/remote-coffee-slack/issues/9